### PR TITLE
Adds Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+os: linux
+dist: xenial
+language: python
+python:
+  - "3.6"
+branches:
+  only:
+  - test
+  - master
+jobs:
+  include:
+    - stage: docker
+      script: docker build . -t build
+    - stage: test
+      install: cp tests/Dockerfile ./Dockerfile
+      script: docker build . -t test      
+stages:
+  - docker
+  - test
+ 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:13.0.1-alpine AS buildstep
+LABEL maintainer "RPS <devops@rpsgroup.com>"
+
+RUN mkdir -p /web
+WORKDIR /web
+
+COPY ./web/ /web/
+RUN yarn global add grunt-cli && \
+    yarn install && \
+    grunt
+
+FROM python:3.6
+
+RUN mkdir -p /glider-dac-status
+RUN mkdir /glider-dac-status/logs
+COPY app.py config.yml flask_environments.py manage.py /glider-dac-status/
+COPY status /glider-dac-status/status
+COPY navo /glider-dac-status/navo
+COPY requirements/requirements.txt /requirements.txt
+COPY tests/test_status.py /glider-dac-status/
+RUN rm -f /glider-dac-status/test/test_status.py
+COPY requirements/test_requirements.txt /test_requirements.txt
+
+WORKDIR /glider-dac-status
+
+RUN apt-get update && \
+    apt-get install -y python3-netcdf4 && \
+    pip install --no-cache cython gunicorn && \
+    pip install --no-cache -r /requirements.txt && \
+    pip install --no-cache -r /test_requirements.txt
+
+COPY --from=buildstep /web/ /glider-dac-status/web
+	
+RUN pytest
+

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -11,8 +11,7 @@ RUN yarn global add grunt-cli && \
 
 FROM python:3.6
 
-RUN mkdir -p /glider-dac-status
-RUN mkdir /glider-dac-status/logs
+RUN mkdir -p /glider-dac-status/logs
 COPY app.py config.yml flask_environments.py manage.py /glider-dac-status/
 COPY status /glider-dac-status/status
 COPY navo /glider-dac-status/navo
@@ -27,7 +26,8 @@ RUN apt-get update && \
     apt-get install -y python3-netcdf4 && \
     pip install --no-cache cython gunicorn && \
     pip install --no-cache -r /requirements.txt && \
-    pip install --no-cache -r /test_requirements.txt
+    pip install --no-cache -r /test_requirements.txt && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=buildstep /web/ /glider-dac-status/web
 	


### PR DESCRIPTION
Travis conducts two tests: one where it simply tries to build the main dockerfile, and one where it builds from a similar dockerfile in the tests directory which then runs pytest in that docker container.