### PR TITLE
Push docker images to dockerhub usingTravis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,17 @@ branches:
 jobs:
   include:
     - stage: docker
-      script: docker build . -t build
+      script: docker build . -t glider-dac-status
     - stage: test
       install: cp tests/Dockerfile ./Dockerfile
       script: docker build . -t test      
 stages:
   - docker
   - test
- 
+deploy:
+  provider: script
+  script: bash "$TRAVIS_BUILD_DIR/scripts/docker_push.sh"
+  on:
+    repo: ioos/glider-dac-status
+    branch: master
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ jobs:
   include:
     - stage: docker
       script: docker build . -t glider-dac-status
+      deploy:
+        provider: script
+        script: bash "$TRAVIS_BUILD_DIR/scripts/docker_push.sh"
+        on:
+          repo: ioos/glider-dac-status
+          branch: master
+          tags: true
     - stage: test
       install: cp tests/Dockerfile ./Dockerfile
-      script: docker build . -t test      
+      script: docker build . -t test
 stages:
   - docker
   - test
-deploy:
-  provider: script
-  script: bash "$TRAVIS_BUILD_DIR/scripts/docker_push.sh"
-  on:
-    repo: ioos/glider-dac-status
-    branch: master
-    tags: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/ioos/glider-dac-status.svg?branch=master)](https://travis-ci.com/ioos/glider-dac-status)
+
 # glider-dac-status
 
 Status Application for Glider DAC

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Dockerhub login
+if [[ ! -n "$DOCKER_PASSWORD" || ! -n "$DOCKER_USERNAME" ]]; then
+  echo "DOCKER_USERNAME and DOCKER_PASSWORD must be set as environment variables!" >&2
+  exit 1
+else
+  docker login -u "$DOCKER_USERNAME" --password-stdin <<< "$DOCKER_PASSWORD"
+
+  if [[ $? -ne 0 ]]; then
+    exit 1
+  fi
+  
+  # if the build is for a pushed tag, use that tag for the Docker image;
+  # otherwise, use "latest (via BASH substitution)"
+  image_release_tag="${TRAVIS_TAG:-latest}"
+  
+  echo "Tagging image with: $image_release_tag"
+  docker tag glider-dac-status:latest ioos/glider-dac-status:$image_release_tag
+  docker push ioos/glider-dac-status
+fi


### PR DESCRIPTION
After building the docker image in the first stage of the Travis test, it pushes to dockerhub.

Also adds a TravisCI badge to the README.