### PR TITLE
Add trajectories to celery task

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 config.local.yml
 *.sw[po]
+web/static/json/trajectories/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.swp
 *.pyc
 logs/
-web/static/json/trajectories/*.json
+web/static/json/trajectories/
 web/npm_components/
 web/node_modules/
 web/static/app/

--- a/app.py
+++ b/app.py
@@ -42,9 +42,13 @@ celery.conf.beat_schedule = {
         "task": "status.tasks.get_dac_status",
         "schedule": crontab(minute="*/15")  # Run every 15 mins
     },
+    "get_dac_trajectories_task": {
+        "task": "status.tasks.get_trajectory_features",
+        "schedule": crontab(minute=10, hour="*/1")  # Run every hr
+    },
     "get_dac_profile_plots_task": {
         "task": "status.tasks.generate_dac_profile_plots",
-        "schedule": crontab(minute=0, hour=[0, 12])  # Run twice a day
+        "schedule": crontab(minute=0, hour='*/6')  # Run 4 times a day
     },
 }
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,3 +17,4 @@ cmocean==2.0
 netCDF4>=1.4.2
 netcdftime>=1.0.0a2
 boto3==1.13.18
+shapely==1.7.0

--- a/status/controller.py
+++ b/status/controller.py
@@ -6,25 +6,26 @@ The controller definition for the status application. This mostly contains the
 routes and logic API
 '''
 
-from status import api
-from status.tasks import get_trajectory
-
-from flask import jsonify, request, current_app
-
 import requests
+from flask import jsonify, current_app
+from status import api
+from status.trajectories import get_trajectory
+
 
 @api.route('/test')
 def test():
     return jsonify(message="Running")
 
-#--------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------
 # Proxies - Use with caution
-#--------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------
 @api.route('/deployment', methods=['GET'])
 def get_deployments():
     url = current_app.config.get('DAC_API')
     response = requests.get(url)
     return response.content, response.status_code, dict(response.headers)
+
 
 @api.route('/deployment/<string:username>/<string:deployment_name>', methods=['GET'])
 def get_deployment(username, deployment_name):
@@ -32,7 +33,7 @@ def get_deployment(username, deployment_name):
     url += '/%s/%s' % (username, deployment_name)
     response = requests.get(url)
     return response.content, response.status_code, dict(response.headers)
-#--------------------------------------------------------------------------------
+
 
 @api.route('/track/<string:username>/<string:deployment_name>')
 def track(username, deployment_name):
@@ -45,4 +46,3 @@ def track(username, deployment_name):
     erddap_url = deployment['erddap']
     geo_data = get_trajectory(erddap_url)
     return jsonify(**geo_data)
-

--- a/status/trajectories.py
+++ b/status/trajectories.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+import requests
+import os
+import sys
+from app import app
+from shapely.geometry import LineString
+from status.profile_plots import iter_deployments, is_recent_data, is_recent_update
+
+
+def get_trajectory(erddap_url):
+    '''
+    Reads the trajectory information from ERDDAP and returns a GEOJSON like
+    structure.
+    '''
+    # https://gliders.ioos.us/erddap/tabledap/ru01-20140104T1621.json?latitude,longitude&time&orderBy(%22time%22)
+    url = erddap_url.replace('html', 'json')
+    # ERDDAP requires the variable being sorted to be present in the variable
+    # list.  The time variable will be removed before converting to GeoJSON
+    url += '?longitude,latitude,time&orderBy(%22time%22)'
+    response = requests.get(url, timeout=180)
+    if response.status_code != 200:
+        raise IOError("Failed to fetch trajectories: {}".format(erddap_url))
+    data = response.json()
+    geo_data = {
+        'type': 'LineString',
+        'coordinates': [c[0:2] for c in data['table']['rows']]
+    }
+
+    geometry = parse_geometry(geo_data)
+    coords = LineString(geometry['coordinates'])
+    trajectory = coords.simplify(0.02, preserve_topology=False)
+    geometry = {
+        'type': 'LineString',
+        'coordinates': list(trajectory.coords),
+        'properties': {
+            'oceansmap_type': 'glider'
+        }
+    }
+    return geometry
+
+
+def get_path(deployment):
+    '''
+    Returns the path to the trajectory file
+
+    :param dict deployment: Dictionary containing the deployment metadata
+    '''
+    trajectory_dir = app.config.get('TRAJECTORY_DIR')
+    username = deployment['username']
+    name = deployment['name']
+    dir_path = os.path.join(trajectory_dir, username)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+    file_path = os.path.join(dir_path, name + '.json')
+    return file_path
+
+
+def write_trajectory(deployment, geo_data):
+    '''
+    Writes a geojson like python structure to the appropriate data file
+
+    :param dict deployment: Dictionary containing the deployment metadata
+    :param dict geometry: A GeoJSON Geometry object
+    '''
+    file_path = get_path(deployment)
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(geo_data))
+
+
+def parse_geometry(geometry):
+    '''
+    Filters out potentially bad coordinate pairs as returned from
+    GliderDAC. Returns a safe geometry object.
+
+    :param dict geometry: A GeoJSON Geometry object
+    '''
+    coords = []
+    for lon, lat in geometry['coordinates']:
+        if lon is None or lat is None:
+            continue
+        coords.append([lon, lat])
+    return {'coordinates': coords}
+
+
+def trajectory_exists(deployment):
+    '''
+    Returns True if the data is within the last week
+
+    :param dict deployment: Dictionary containing the deployment metadata
+    '''
+
+    file_path = get_path(deployment)
+    return os.path.exists(file_path)
+
+
+def generate_trajectories(deployments=None):
+    '''
+    Determine which trajectories need to be built, and write geojson to file
+    '''
+    for deployment in iter_deployments():
+        try:
+            # Only add if the deployment has been recently updated or the data is recent
+            recent_update = is_recent_update(deployment['updated'])
+            recent_data = is_recent_data(deployment)
+            existing_trajectory = trajectory_exists(deployment)
+            if (recent_update or recent_data or not existing_trajectory):
+                geo_data = get_trajectory(deployment['erddap'])
+                write_trajectory(deployment, geo_data)
+        except Exception:
+            from traceback import print_exc
+            print_exc()
+    return 0
+
+
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+    parser = ArgumentParser(description=generate_trajectories.__doc__)
+    parser.add_argument(
+        '-d', '--deployment',
+        action='append',
+        help='Which deployment to build'
+    )
+    args = parser.parse_args()
+    sys.exit(generate_trajectories(args.deployment))


### PR DESCRIPTION
@benjwadams this update adds the trajectories used in OceansMap to be built on this celery beat schedule rather than on demand. Also only updates the trajectories when needed.